### PR TITLE
Provide `Dockerfile` and improve `install.md`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update && apt-get install -y \
     libglu1-mesa-dev \
     freeglut3-dev \
     zlib1g-dev \
-    libpcap-dev
+    libpcap-dev \
+    libtbb-dev
 
 # Install GTSAM
 RUN git clone https://github.com/borglab/gtsam.git /gtsam && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+FROM ubuntu:20.04
+
+# Set non-interactive mode for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libboost-dev \
+    libyaml-cpp-dev \
+    libomp-dev \
+    flex \
+    bison \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install CMake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-linux-x86_64.sh && \
+    sh cmake-3.25.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.25.3-linux-x86_64.sh
+
+# Install additional dependencies
+RUN apt-get update && apt-get install -y \
+    libboost-all-dev \
+    libeigen3-dev \
+    pkg-config \
+    libflann-dev \
+    libusb-1.0-0-dev \
+    libpng-dev \
+    libqhull-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    freeglut3-dev \
+    zlib1g-dev \
+    libpcap-dev
+
+# Install GTSAM
+RUN git clone https://github.com/borglab/gtsam.git /gtsam && \
+    cd /gtsam && \
+    git checkout 4f66a491ffc83cf092d0d818b11dc35135521612 && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make -j4 && \
+    make install
+
+# Install VTK and Qt
+RUN apt-get update && apt-get install -y \
+    libvtk7-dev \
+    qtbase5-dev \
+    libqt5opengl5-dev \
+    libglew-dev \
+    libxi-dev \
+    libxmu-dev
+
+# Install PCL 1.10.0
+RUN git clone https://github.com/PointCloudLibrary/pcl.git /pcl && \
+    cd /pcl && \
+    git checkout pcl-1.10.0 && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make -j4 && \
+    make install
+
+# Install GLOG
+RUN git clone https://github.com/google/glog.git /glog && \
+    cd /glog && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make -j4 && \
+    make install
+
+# Install iGraph
+RUN git clone https://github.com/igraph/igraph.git /igraph && \
+    cd /igraph && \
+    git checkout 0.9.9 && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make -j4 && \
+    make install
+
+# Set the working directory
+WORKDIR /G3Reg

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,14 +1,32 @@
-# Step-by-step installation instructions
+# Installation Instructions
+
+```shell
+git clone https://github.com/HKUST-Aerial-Robotics/G3Reg
+cd G3Reg
+```
+
+## Docker
+
+You can use Docker to simplify the installation process and avoid manual dependency management.
+
+```shell
+docker build -t g3reg .
+docker run -it -v "$(pwd)":/root/G3Reg -w /root/G3Reg g3reg bash
+```
+
+This will start a container with all dependencies pre-installed and mount your current project directory into the container.
+
+## Manual Installation (Without Docker)
 
 **a. Install packages from ubuntu source.**
 
 ```shell
-sudo apt install libboost-dev libyaml-cpp-dev libomp-dev
+sudo apt install libboost-dev libyaml-cpp-dev libomp-dev libtbb-dev
 ```
 
 **b. Follow the official guidance to install [GTSAM-4.2](https://github.com/borglab/gtsam/tree/4f66a491ffc83cf092d0d818b11dc35135521612), [PCL-1.10](https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.10.0), [GLOG](https://github.com/google/glog).**
 
-> **Notice**:
+> **Note**:
 >
 > - `GTSAM-4.2` is not compatible with `Eigen-3.4.0`. Use a version below 3.4.0, such as `Eigen-3.3.7`.
 > - `PCL-1.11` and later versions remove support for `boost::make_shared` in favor of `std::make_shared`, which is not compatible with this project. Use a version below 1.11, such as `PCL-1.10`.
@@ -27,10 +45,9 @@ make -j4
 sudo make install
 ```
 
-**d. Build**
+## Build and Compile
 
-```angular2html
-cd G3Reg
+```shell
 mkdir build && cd build
 cmake ..
 make -j4

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,11 +1,21 @@
 # Step-by-step installation instructions
+
 **a. Install packages from ubuntu source.**
+
 ```shell
 sudo apt install libboost-dev libyaml-cpp-dev libomp-dev
 ```
-**b. Follow the official guidance to install [GTSAM-4.2](https://github.com/borglab/gtsam/tree/4f66a491ffc83cf092d0d818b11dc35135521612), [PCL](https://github.com/PointCloudLibrary/pcl), [GLOG](https://github.com/google/glog).**
+
+**b. Follow the official guidance to install [GTSAM-4.2](https://github.com/borglab/gtsam/tree/4f66a491ffc83cf092d0d818b11dc35135521612), [PCL-1.10](https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.10.0), [GLOG](https://github.com/google/glog).**
+
+> **Notice**:
+>
+> - `GTSAM-4.2` is not compatible with `Eigen-3.4.0`. Use a version below 3.4.0, such as `Eigen-3.3.7`.
+> - `PCL-1.11` and later versions remove support for `boost::make_shared` in favor of `std::make_shared`, which is not compatible with this project. Use a version below 1.11, such as `PCL-1.10`.
+> - To install the PCL visualization module, install VTK and Qt before installing PCL.
 
 **c. Install iGraph 0.9.9 (To support [3DMAC](https://github.com/zhangxy0517/3D-Registration-with-Maximal-Cliques))**
+
 ```shell
 sudo apt-get install flex bison
 git clone https://github.com/igraph/igraph.git
@@ -16,7 +26,9 @@ cmake ..
 make -j4
 sudo make install
 ```
+
 **d. Build**
+
 ```angular2html
 cd G3Reg
 mkdir build && cd build


### PR DESCRIPTION
## Changes
- Clarified Eigen version requirement: Explicitly state that GTSAM-4.2 is incompatible with Eigen-3.4.0 and recommend using Eigen-3.3.7 or lower.
- Specified PCL version compatibility: Emphasize that PCL-1.11+ is not supported due to changes in shared pointer usage, and recommend PCL-1.10.
- Added note on visualization dependencies: Remind users to install VTK and Qt before building PCL if visualization is needed.

## Motivation
Users have encountered build errors due to incompatible library versions (#15, #16, #19). This update aims to prevent such issues by providing clearer guidance.
